### PR TITLE
Add a Composer file, so Composer can install the module directly from a path or VCS repository.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+  "name": "drupal/veoa",
+  "description": "Provides a Views access control plugin checking if the user can perform an operation on an entity in context.",
+  "type": "drupal-module",
+  "license": "GPL-2.0",
+  "autoload": {
+    "psr-4": {
+      "Drupal\\veoa\\": "src"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Drupal\\Tests\\veoa\\": "tests/src"
+    }
+  }
+}


### PR DESCRIPTION
This exposes the module as a proper Composer package, making it installable through Composer using all the other methods besides https://packagist.drupal-composer.org or the Drupal.org Packagist. For us this means we can keep a fork of the module, and experiment with patches we need for client projects, to propose them back upstream (meaning your original repository) when they're stable and useful enough.
